### PR TITLE
Fix a rare corner case when cycling a sentinel value

### DIFF
--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -157,14 +157,16 @@ function newsentinel!(arrays::SentinelArray{T, N, S, V}...; force::Bool=true) wh
     newsent = newsentinel(T)
     # find a new sentinel that doesn't already exist in parent
     while true
-        foundnewsent = false
-        for A in arrays
-            p = parent(A)
-            for i in eachindex(p)
-                @inbounds z = p[i]
-                if eq(z, newsent)
-                    foundnewsent = true
-                    break
+        foundnewsent = eq(oldsent, newsent)
+        if !foundnewsent
+            for A in arrays
+                p = parent(A)
+                for i in eachindex(p)
+                    @inbounds z = p[i]
+                    if eq(z, newsent)
+                        foundnewsent = true
+                        break
+                    end
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,20 @@
-using SentinelArrays, Test
+using SentinelArrays, Test, Random
 
 @testset "SentinelArrays" begin
+
+# this is a very rare corner case
+# we put this test first because it relies on
+# the seeded random number generator for thread 1
+# the issue is if we had an underlying array of non-sentinel values
+# then tried to `setindex!` to the _NEXT_ chosen sentinel value
+# then the element getting set would end up `missing` (because it == the sentinel value)
+# instead of the sentinel value getting cycled to something else
+Random.seed!(SentinelArrays.RNG[1], 0)
+x = SentinelVector{Int}(undef, 1)
+x[1] = 1
+x.sentinel = 1369352191816061504
+x[1] = 1369352191816061504
+@test x[1] == 1369352191816061504
 
 x = SentinelVector{Int}(undef, 10)
 fill!(x, missing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using SentinelArrays, Test, Random
 # then the element getting set would end up `missing` (because it == the sentinel value)
 # instead of the sentinel value getting cycled to something else
 Random.seed!(SentinelArrays.RNG[1], 0)
-x = SentinelVector{Int}(undef, 1)
+x = SentinelVector{Int64}(undef, 1)
 x[1] = 1
 x.sentinel = 1369352191816061504
 x[1] = 1369352191816061504


### PR DESCRIPTION
sudete on discourse pointed out that there's a corner case not currently
covered when cycling to a new sentinel value. We might try to be
`setindex!`ing a value that is equal to our sentinel value, so we go to
pick a new sentinel, and it might be possible for the newly chosen
sentinel to be equal to the current sentinel, which would pass the "new
sentinel" check because it doesn't exist in the current array. The fix
here is to ensure the newly chosen sentinel is also not the same as the
existing sentinel