### PR TITLE
Work around an inconsistency when deleting from arrays with #undef

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,12 @@ x[1] = missing
 @test x[1] === missing
 
 x = SentinelVector{String}(undef, 10)
+deleteat!(x, [1,3,5,7,9])
+@test length(x) == 5
+deleteat!(x, [true, false, true, false, true])
+@test length(x) == 2
+
+x = SentinelVector{String}(undef, 10)
 @test x[1] === missing
 x[1] = "hey"
 @test x[1] == "hey"


### PR DESCRIPTION
elements

In `Base.deleteat!`, you're allowed to pass an `Integer` or `UnitRange`
argument, and they work fine with `#undef` elements, but when passing
`inds` or `AbstractVector{Bool}`, elements are accessed, causing
`UndefRefError`s. We put a work-around in place until this inconsistency
can be resolved in Base.

Fixes https://github.com/JuliaData/SentinelArrays.jl/issues/18