### PR TITLE
Remove unnecessary code in ChainedVector index

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -30,7 +30,6 @@ Base.size(x::ChainedVector) = (length(x.inds) == 0 ? 0 : x.inds[end],)
 
 @inline function index(A::ChainedVector, i::Integer)
     chunk = searchsortedfirst(A.inds, i)
-    @inbounds x = A.arrays[chunk][i - (chunk == 1 ? 0 : A.inds[chunk - 1])]
     return chunk, i - (chunk == 1 ? 0 : A.inds[chunk - 1])
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,6 +263,10 @@ c2 = copy(c)
 @test length(c) == length(c2)
 @test c2 isa SentinelVector
 
+# deleteat! of SentinelArray w/ underlying ChainedVector w/ UndefInitializer
+x = SentinelArray(ChainedVector([Vector{String}(undef, 5)]))
+deleteat!(x, 1)
+@test length(x) == 4
 
 end # @testset
 


### PR DESCRIPTION
This line must have been from an inadvertent code refactor splitting
getindex into index + getindex. We don't need to access individual
elements when just determining the chunk and chunk index from overall
index. This caused an issue (reported by @ararslan on slack) in
deleteat! which uses `index` to figure out what to delete.