### PR TITLE
Fix deleteat! with empty inds array

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -154,8 +154,6 @@ Base.@propagate_inbounds function Base.deleteat!(A::ChainedVector, i::Integer)
 end
 
 Base.@propagate_inbounds function Base.deleteat!(A::ChainedVector, inds)
-    @boundscheck checkbounds(A, first(inds))
-    @boundscheck checkbounds(A, last(inds))
     for i in reverse(inds)
         deleteat!(A, i)
     end

--- a/src/missingvector.jl
+++ b/src/missingvector.jl
@@ -49,8 +49,6 @@ Base.@propagate_inbounds function Base.deleteat!(x::MissingVector, i::Integer)
 end
 
 Base.@propagate_inbounds function Base.deleteat!(x::MissingVector, inds)
-    @boundscheck checkbounds(x, first(inds))
-    @boundscheck checkbounds(x, last(inds))
     for i in reverse(inds)
         deleteat!(x, i)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -413,6 +413,9 @@ deleteat!(x, b)
 @test x[1] == 2
 @test length(x) == 9
 
+deleteat!(x, Int[])
+@test length(x) == 9
+
 end
 
 @testset "MissingVector" begin
@@ -534,5 +537,8 @@ c = ChainedVector([m, m, m])
 c2 = copy(c)
 @test length(c) == length(c2)
 @test c2 isa MissingVector
+
+deleteat!(c2, Int[])
+@test length(c2) == 15
 
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/690. The issue here is we weren't
testing or accounting for the case when the `inds` arguement to deleteat! is empty.
This comes up in practice from `dropmissing!` in DataFrames.jl when there are no missing
values in a column, it still calls `deleteat!` with the empty array.
The fix is pretty straightforward: we can just remove the bounds checks here because
we're doing the bounds check in the underlying `::Integer` method anyway.