### PR TITLE
`MissingVector` length should be of type Int

### DIFF
--- a/src/missingvector.jl
+++ b/src/missingvector.jl
@@ -1,5 +1,5 @@
 mutable struct MissingVector <: AbstractVector{Missing}
-    len::Int64
+    len::Int
 end
 
 Base.IndexStyle(::Type{MissingVector}) = Base.IndexLinear()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -423,6 +423,7 @@ end
 x = MissingVector(10)
 @test all(x .=== missing)
 @test length(x) == 10
+@test length(x) isa Int
 @test Base.IndexStyle(x) == Base.IndexLinear()
 
 y = similar(x, Missing, 5)


### PR DESCRIPTION
On 32-bit systems having `MissingVector` return a length of `Int64` is problematic when working with DataFrames:
```julia
julia> using DataFrames, SentinelArrays

julia> df = DataFrame(:a => MissingVector(0));

julia> size(df, 1)
ERROR: TypeError: in typeassert, expected Int32, got Int64
Stacktrace:
 [1] nrow(::DataFrame) at /home/omus/.julia/packages/DataFrames/lfoTw/src/dataframe/dataframe.jl:346
 [2] size(::DataFrame, ::Int32) at /home/omus/.julia/packages/DataFrames/lfoTw/src/abstractdataframe/abstractdataframe.jl:323
 [3] top-level scope at REPL[13]:1

julia> typeof(length(MissingVector(0)))
Int64
```