### PR TITLE
Fix iteration issue when chains have zero-length

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SentinelArrays"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.2.10"
+version = "1.2.11"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -19,6 +19,7 @@ function ChainedVector(arrays::Vector{A}) where {A <: AbstractVector{T}} where {
     inds = Vector{Int}(undef, n)
     x = 0
     @inbounds for i = 1:n
+        # note that arrays[i] can have zero length
         x += length(arrays[i])
         inds[i] = x
     end
@@ -57,7 +58,6 @@ end
     while i > chunk_len
         chunk += 1
         @inbounds chunk_len = A.inds[chunk]
-        i <= chunk_len && break
     end
     x = A.arrays[chunk][1]
     # find next valid index

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -543,23 +543,43 @@ deleteat!(c2, Int[])
 @test length(c2) == 15
 
 @testset "iteration protocol on ChainedVector" begin
-    @test isnothing(iterate(ChainedVector([[]])))
     for len in 0:6
+        cv = ChainedVector([1:len])
+        @test length(cv) == len
+        c = 0
+        for (i, v) in enumerate(cv)
+            c += 1
+            @test i == v
+        end
+        @test c == len
         for j in 0:len
             cv = ChainedVector([1:j, j+1:len])
+            @test length(cv) == len
+            c = 0
             for (i, v) in enumerate(cv)
+                c += 1
                 @test i == v
             end
+            @test c == len
             for k in j:len
                 cv = ChainedVector([1:j, j+1:k, k+1:len])
+                @test length(cv) == len
+                c = 0
                 for (i, v) in enumerate(cv)
+                    c += 1
                     @test i == v
                 end
+                @test c == len
+
                 for l in k:len
                     cv = ChainedVector([1:j, j+1:k, k+1:l, l+1:len])
+                    @test length(cv) == len
+                    c = 0
                     for (i, v) in enumerate(cv)
+                        c += 1
                         @test i == v
                     end
+                    @test c == len
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -542,4 +542,28 @@ c2 = copy(c)
 deleteat!(c2, Int[])
 @test length(c2) == 15
 
+@testset "iteration protocol on ChainedVector" begin
+    @test isnothing(iterate(ChainedVector([[]])))
+    for len in 0:6
+        for j in 0:len
+            cv = ChainedVector([1:j, j+1:len])
+            for (i, v) in enumerate(cv)
+                @test i == v
+            end
+            for k in j:len
+                cv = ChainedVector([1:j, j+1:k, k+1:len])
+                for (i, v) in enumerate(cv)
+                    @test i == v
+                end
+                for l in k:len
+                    cv = ChainedVector([1:j, j+1:k, k+1:l, l+1:len])
+                    for (i, v) in enumerate(cv)
+                        @test i == v
+                    end
+                end
+            end
+        end
+    end
+end
+
 end


### PR DESCRIPTION
Fixes #27. The issue here is that `iterate` for `ChainedVector` was
assuming that underlying array chains wouldn't have zero-length. If a
user is doing a lot of filtering/deleting, however, it might be the case
that certain chunks end up with zero-length (though we do try to prune
those out when possible, so I'm still a little unsure how we get in this
state). Nevertheless, this assumption is a bit optimistic, and we can do
better by just checking if the next chunk is zero-length when iterating
and moving on to the next chunk if so.