### PR TITLE
Make deletat! for SentinelArray/ChainedVector much faster

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -41,6 +41,19 @@ Base.@propagate_inbounds function Base.getindex(A::ChainedVector, i::Integer)
     return x
 end
 
+Base.@propagate_inbounds function Base.isassigned(A::ChainedVector, i::Integer)
+    @boundscheck checkbounds(A, i)
+    chunk, ix = index(A, i)
+    return @inbounds isassigned(A.arrays[chunk], ix)
+end
+
+# Base.@propagate_inbounds function Base.getindex(A::ChainedVector, chunk::Integer, i::Integer)
+#     @boundscheck checkbounds(A.arrays, chunk)
+#     @boundscheck checkbounds(A.arrays[chunk], i)
+#     @inbounds x = A.arrays[chunk][i]
+#     return x
+# end
+
 Base.@propagate_inbounds function Base.setindex!(A::ChainedVector, v, i::Integer)
     @boundscheck checkbounds(A, i)
     chunk, ix = index(A, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,6 +416,11 @@ deleteat!(x, b)
 deleteat!(x, Int[])
 @test length(x) == 9
 
+#30
+x = ChainedVector([Vector{String}(undef, 3), ["hey", "ho"]])
+@test !isassigned(x, 1)
+@test isassigned(x, 4)
+
 end
 
 @testset "MissingVector" begin


### PR DESCRIPTION
Previously, we were taking the most naive route possible. These new
algorithms are now much faster and attempt to take as many fast paths as
possible. For SentinelArray, we use the Base definition for all cases
except when a SentinelArray uses `#undef` for sentinel and has multiple
deletions, since the Base algorithm is inconsistent in allowing `#undef`
to be deleted. We copy-paste the Base algorithm in that case and handle
the `#undef`s specially.

For ChainedVector, we use a new algorithm that iterates indices to
delete and accumulates them per "chunk", thus moving from an algorithm
of one deletion per index, to one deletion call per chunk, which makes
it must faster.

Fixed #23.