### PR TITLE
Fix deleteat for SentinelArrays with undef and integer inds

### DIFF
--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -289,7 +289,7 @@ function Base.deleteat!(A::SentinelVector{T, S, V, AT}, inds) where {T, S, V, AT
             end
             p += !i
         end
-        deleteat!(parent(A), n - p + 1:n)
+        deleteat!(parent(A), n - p + 2:n)
     else
         _deleteat!(A, inds)
     end
@@ -334,7 +334,7 @@ function _deleteat!(a::SentinelVector, inds)
         end
         p += 1; q += 1
     end
-    deleteat!(parent(a), n - p + 2:n)
+    deleteat!(parent(a), p:n)
     return a
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,11 +94,13 @@ x[1] = true
 x[1] = missing
 @test x[1] === missing
 
-x = SentinelVector{String}(undef, 10)
-deleteat!(x, [1,3,5,7,9])
-@test length(x) == 5
-deleteat!(x, [true, false, true, false, true])
-@test length(x) == 2
+x = SentinelArray(["$i" for i = 1:10])
+deleteat!(x, [9, 10])
+@test length(x) == 8
+@test x == ["$i" for i = 1:8]
+deleteat!(x, [true, false, true, false, true, false, true, false])
+@test length(x) == 4
+@test x == ["2", "4", "6", "8"]
 
 x = SentinelVector{String}(undef, 10)
 @test x[1] === missing


### PR DESCRIPTION
Fixes #32. The issue here was a confusion between using deleteat and
_deleteend from Base, so we ended up deleting more elemnts than we
should.