### PR TITLE
Make copy, similar and getindex fallback to Array

### DIFF
--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -113,14 +113,6 @@ end
 Base.convert(::Type{SentinelArray}, arr::AbstractArray{T}) where {T} = convert(SentinelArray{T}, arr)
 Base.convert(::Type{SentinelVector{T}}, arr::AbstractArray) where {T} = convert(SentinelArray{T}, arr)
 
-function Base.similar(A::SentinelArray{T, N, S, V}, ::Type{T2}, dims::Dims{N2}) where {T, N, S, V, T2, N2}
-    if T2 >: V
-        SentinelArray{Core.Compiler.typesubtract(T2, V)}(undef, dims)
-    else
-        similar(parent(A), T2, dims)
-    end
-end
-
 Base.empty(A::SentinelVector{T}, ::Type{U}=T) where {T, U} = SentinelVector{U}(undef, 0)
 # Base.emptymutable(A::SentinelVector{T}, ::Type{U}=T) where {T, U} = SentinelVector{U}(undef, 0)
 
@@ -243,8 +235,6 @@ function Base.empty!(A::SentinelVector)
     empty!(parent(A))
     return A
 end
-
-Base.copy(A::SentinelArray{T, N}) where {T, N} = SentinelArray(copy(parent(A)), A.sentinel, A.value)
 
 function Base.resize!(A::SentinelVector{T}, len) where {T}
     oldlen = length(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,28 +40,6 @@ x = SentinelVector{Int64}(undef, 1)
 x[1] = missing
 @test x[1] === missing
 
-y = similar(x)
-@test typeof(parent(x)) == typeof(parent(y))
-@test y[1] === missing
-y = similar(x, 20)
-@test typeof(parent(x)) == typeof(parent(y))
-@test y[1] === missing
-y = similar(x, (10, 10))
-@test eltype(parent(x)) == eltype(parent(y))
-@test y[1] === missing
-y = similar(x, Union{Missing, Float64})
-@test eltype(parent(y)) === Float64
-@test y[1] === missing
-y = similar(x, Union{Missing, Float64}, 10)
-@test eltype(parent(y)) === Float64
-@test y[1] === missing
-@test length(y) == 10
-y = similar(x, Union{Missing, Float64}, (10, 10))
-@test eltype(parent(y)) === Float64
-@test y[1] === missing
-y = similar(x, Float64, 10)
-@test y isa Vector{Float64}
-
 x = SentinelArray{Float64, 2}(undef, 10, 10)
 @test size(x) == (10, 10)
 x = SentinelArray{Float64}(undef, 10, 10)
@@ -147,8 +125,6 @@ insert!(x, length(x) + 1, "pirate")
 @test splice!(x, length(x), ["pirate2"]) == "pirate"
 @test splice!(x, length(x)) == "pirate2"
 @test splice!(x, length(x), ["pirate3", "pirate4"]) === missing
-@test x[end-1:end] == ["pirate3", "pirate4"]
-@test typeof(x[end-1:end]) == typeof(x)
 
 @test splice!(x, (length(x)-1):length(x), ["pirate5", "pirate6"]) == ["pirate3", "pirate4"]
 @test splice!(x, (length(x)-1):length(x), ["pirate7"]) == ["pirate5", "pirate6"]


### PR DESCRIPTION
Fixes #34

It seems that this improves `getindex` timing but reduces `copy` time (which needs to convert the sentinel):

Before this PR:
```
julia> x = SentinelArray(rand(10^6));

julia> @btime copy($x);
  442.980 μs (3 allocations: 7.63 MiB)

julia> @btime similar($x);
  251.363 μs (6 allocations: 7.63 MiB)

julia> @btime $x[10^5:-1:1];
  173.375 μs (6 allocations: 781.50 KiB)
```

This PR:
```
julia> x = SentinelArray(rand(10^6));

julia> @btime copy($x);
  1.412 ms (2 allocations: 8.58 MiB)

julia> @btime similar($x);
  265.543 μs (2 allocations: 8.58 MiB)

julia> @btime $x[10^5:-1:1];
  155.686 μs (2 allocations: 879.02 KiB)
```

Still - I believe that all these operations are one-time only, so even the regression for `copy` is acceptable I think (and `copy` is not that bad - it is quite fast anyway). The reality (as I assume), is that `SentinelArray` will be mostly created only when you read-in the data.

(I would expect that for `ChainedVector` backed `SentinelVector` to see a similar situation)