### PR TITLE
Fix deleteat on ChainedVector that spans multiple array chains

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -399,6 +399,11 @@ x = ChainedVector([Vector{String}(undef, 3), ["hey", "ho"]])
 @test !isassigned(x, 1)
 @test isassigned(x, 4)
 
+#36
+x = ChainedVector([[1,2,3], [4,5,6], [7,8,9], [10,11,12]])
+deleteat!(x, [1, 2, 10, 11])
+@test x == [3, 4, 5, 6, 7, 8, 9, 12]
+
 end
 
 @testset "MissingVector" begin


### PR DESCRIPTION
Fixes #36. The issue here is when a deleteat! was called with integer
indices that spanned multiple array chains, the ChainedVector index
trackers got messed up. We were trying to keep track of what the indices
should be while iterating through chains and deleting, but that's pretty
complicated to get right because when you skip chains, you need to go
back and update them. Anyway, the solution is to stop trying to update
while deleting, and just reset all the indices when we're done with all
the deleting. That ensures the indices will be correct, no matter what
or how many chains were affected by deleting.