### PR TITLE
Fix deleteat! on ChainedVector when multiple chunks are deleted

### DIFF
--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -227,7 +227,7 @@ Base.@propagate_inbounds function Base.setindex!(A::SentinelArray{T, N, S, V}, v
 end
 
 # other AbstractArray functions
-function Base.reverse(A::SentinelVector, s=first(LinearIndices(A)), n=last(LinearIndices(A)))
+function Base.reverse(A::SentinelVector, s::Integer=first(LinearIndices(A)), n::Integer=last(LinearIndices(A)))
     return SentinelArray(reverse(parent(A), s, n), A.sentinel, A.value)
 end
 

--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -221,7 +221,7 @@ Base.@propagate_inbounds function Base.deleteat!(A::ChainedVector, inds)
             A.inds[j] = x
         end
     end
-    for j in todelete
+    for j in Iterators.reverse(todelete)
         deleteat!(A.arrays, j)
         deleteat!(A.inds, j)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -404,6 +404,12 @@ x = ChainedVector([[1,2,3], [4,5,6], [7,8,9], [10,11,12]])
 deleteat!(x, [1, 2, 10, 11])
 @test x == [3, 4, 5, 6, 7, 8, 9, 12]
 
+#38
+A = ChainedVector([collect(((i - 1) * 153 + 1):(i * 153 + 1)) for i = 1:16])
+inds = collect(1:1883)
+deleteat!(A, inds)
+@test length(A) == 581
+
 end
 
 @testset "MissingVector" begin


### PR DESCRIPTION
Fixes #38. The issue here was when deleting spanned multiple chunks of a
ChainedVector, we were then going through and "cleaning up" the chunks
after filtering and were deleting the chunks via forward iteration,
which messed up deleting as the later chunks changed index. By deleting
the chunks in reverse, we ensure hte correct chunks are removed.