### PR TITLE
RFC: JuliaFolds interfaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,17 @@ version = "1.2.16"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FGenerators = "4fd0377b-cfdc-4941-97f4-8d7ddbb8981e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"
 
 [compat]
 julia = "1"
 
 [extras]
+Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
+SplittablesTesting = "3bda5eb5-c32a-4f64-8618-df3be8968470"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Folds", "SplittablesTesting", "Test"]

--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -451,6 +451,7 @@ end
 
 include("chainedvector.jl")
 include("missingvector.jl")
+include("folds.jl")
 
 include("precompile.jl")
 _precompile_()

--- a/src/folds.jl
+++ b/src/folds.jl
@@ -1,0 +1,17 @@
+using FGenerators: @fgenerator, @yield
+using SplittablesBase: SplittablesBase
+
+@fgenerator(A::ChainedVector) do
+    for array in A.arrays
+        for x in array
+            @yield x
+        end
+    end
+end
+
+function SplittablesBase.halve(A::ChainedVector)
+    chunk = searchsortedfirst(A.inds, length(A) ÷ 2)
+    left = @view A.arrays[1:chunk]
+    right = @view A.arrays[chunk+1:end]
+    return (Iterators.flatten(left), Iterators.flatten(right))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using SentinelArrays, Test, Random
+using SentinelArrays, Test, Random, SplittablesTesting, Folds
 
 @testset "SentinelArrays" begin
 
@@ -578,6 +578,25 @@ deleteat!(c2, Int[])
             end
         end
     end
+end
+
+unitrange_chainedvectors = map(1:100) do seed
+    rng = MersenneTwister(seed)
+    ends = cumsum(rand(rng, 0:9, rand(rng, 1:100)))
+    starts = pushfirst!(ends[1:end-1] .+ 1, 1)
+    cv = ChainedVector((:).(starts, ends))
+    return (label = "seed=$seed", data = cv)
+end
+
+@testset "Folds" begin
+    @testset "$label" for (label, data) in unitrange_chainedvectors
+        @test Folds.collect(data, SequentialEx()) == 1:length(data)
+        @test Folds.collect(data) == 1:length(data)
+    end
+end
+
+@testset "SplittablesBase" begin
+    SplittablesTesting.test_unordered(unitrange_chainedvectors)
 end
 
 end


### PR DESCRIPTION
This patch implements two JuliaFolds interfaces on `ChainedVector`: the sequential iteration protocol (aka `foldl`) using [FGenerators.jl](https://github.com/JuliaFolds/FGenerators.jl) syntax and [SplittablesBase.jl](https://github.com/JuliaFolds/SplittablesBase.jl) interface for parallel reductions.

Arguably, the dependency tree pulled via FGenerators.jl, especially Transducers.jl, is rather large. I'm not sure if you want to pull this in at this stage (i.e., probably you'd want to wait until I extract it out as FoldsBase.jl). But I thought it'd be interesting to demonstrate that using JuliaFolds' iteration facility can be beneficial for not only parallel reduction but also for sequential iterations. For example, maybe this can make some parts of the optimization like #42 easier.

This patch uses FGenerators.jl which is a syntax sugar of [`Transducers.__foldl__`](https://juliafolds.github.io/Transducers.jl/dev/howto/reducibles/). This is mainly because writing `__foldl__` is slightly tedious and also I may need to tweak the interface for solving some subtle problems in parallel reduction at some point. But I expect the syntax sugar provided by FGenerators.jl to be more stable.

### Microbenchmark

A simple summation of `ChainedVector{Int}` is 4x faster with `@floop` that uses `foldl` as the iteration mechanism. Looking into LLVM, `@floop` version is vectorized but `iterate` version is not. I think it's a big win, also considering that the `@yield`-based syntax is much simpler than the complex `iterate` implementation.

```julia
julia> using FLoops

julia> function sum_iter(xs)
           acc = zero(eltype(xs))
           for x in xs
               acc += x
           end
           acc
       end
sum_iter (generic function with 1 method)

julia> function sum_foldl(xs)
           @floop begin
               acc = zero(eltype(xs))
               for x in xs
                   acc += x
               end
           end
           acc
       end
sum_foldl (generic function with 1 method)

julia> A = ChainedVector([ones(Int, 2^8) for _ in 1:2^8]);

julia> @btime sum_iter(A)
  43.279 μs (1 allocation: 16 bytes)
65536

julia> @btime sum_foldl(A)
  9.500 μs (1 allocation: 16 bytes)
65536
```

Note: I'm using `Int` as the element type so that vectorization can be triggered easily. Supporting `@simd` for floats is possible but ATM it requires a rather [ugly macro](https://github.com/JuliaFolds/Transducers.jl/blob/2cfb4ccca0f8be9de492146fcb0f982aa6d1d88a/src/simd.jl#L35-L42).
