### PR TITLE
Fix append on Vector with ChainedVector

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -592,6 +592,13 @@ function Base.append!(A::ChainedVector{T}, B) where {T}
     return A
 end
 
+function Base.append!(a::Vector, items::ChainedVector)
+    n = length(items)
+    Base._growend!(a, n)
+    copyto!(a, length(a)-n+1, items, 1, n)
+    return a
+end
+
 function Base.prepend!(A::ChainedVector{T, AT}, B::AT) where {T, AT <: AbstractVector{T}}
     pushfirst!(A.arrays, B)
     n = length(B)

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -361,6 +361,11 @@
     x2 = map(identity, x)
     copyto!(x2, 2, y, 2)
     @test x2[2:end] == y[2:end]
+
+    # https://github.com/JuliaData/SentinelArrays.jl/issues/45
+    a = []
+    append!(a, ChainedVector([[1, 2, 3]]))
+    @test length(a) == 3
 end
 
 @testset "iteration protocol on ChainedVector" begin


### PR DESCRIPTION
Fixes issue #45. The issue here is that the `Base.append!`
implementation relies on calling `first(eachindex(items))`, which has
now been optimized to return a custom type for `ChainedVector`. The
quick work-around is we just overload `Base.append!` when the appending
items is `ChainedVector`, since the definition is so small anyway. If we
end up hearing of other issues with this custom `eachindex` on
`ChainedVector`, we may need to move it back to a more traditional
definition.