### PR TITLE
Removes conflicts between sentinels values

### DIFF
--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -4,11 +4,14 @@ using Dates, Random
 
 export SentinelArray, SentinelMatrix, SentinelVector, SentinelCollisionError, ChainedVector, MissingVector
 
-const RNG = [MersenneTwister()]
+const RNG = []
 
 function __init__()
-    Threads.resize_nthreads!(RNG)
-    return
+    nthr = Threads.nthreads()
+    resize!(RNG, nthr)
+    for i = 1:nthr
+        RNG[i] = MersenneTwister()
+    end
 end
 
 """


### PR DESCRIPTION
A different seed for each RNG element removes potential conflicts between sentinel values.

This may be a problem in reading many files simultaneously as evidenced by https://github.com/JuliaData/CSV.jl/issues/839
