### PR TITLE
Define size for ChainedVector IndexIterator

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -216,6 +216,7 @@ struct IndexIterator{A}
     arrays::Vector{A}
 end
 
+Base.size(x::IndexIterator) = (length(x),)
 Base.length(x::IndexIterator) = sum(length, x.arrays)
 Base.eltype(::Type{IndexIterator{A}}) where {A <: AbstractVector} = ChainedVectorIndex{A}
 

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -366,6 +366,9 @@
     a = []
     append!(a, ChainedVector([[1, 2, 3]]))
     @test length(a) == 3
+
+    # https://github.com/JuliaData/CSV.jl/issues/842
+    @test size(eachindex(ChainedVector([["a"]]))) == (1,)
 end
 
 @testset "iteration protocol on ChainedVector" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/842. I admit to not
exactly understand why this is needed, except that the `InvertedIndex`
type ends up hitting a generic `axes` method in Base where `size` is
expected to be defined on the ChainedVector `IndexIterator` type.