### PR TITLE
Make ChainedVectorIndex <: Integer

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -197,7 +197,7 @@ for f in (:+, :-, :*, :<, :>, :<=, :>=)
     @eval $f(a::ChainedVectorIndex, b::Integer) = $f(a.i, b)
     @eval $f(a::Integer, b::ChainedVectorIndex) = $f(a, b.i)
 end
-Base.convert(::Type{T}, x::ChainedVectorIndex) where {T <: Union{Signed, Unsigned}} = x.i
+Base.convert(::Type{T}, x::ChainedVectorIndex) where {T <: Union{Signed, Unsigned}} = convert(T, x.i)
 
 @inline Base.getindex(x::ChainedVectorIndex) = @inbounds x.array[x.array_i]
 

--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -192,8 +192,8 @@ struct ChainedVectorIndex{A} <: Integer
     i::Int
 end
 
-import Base: +, -, *, <, >, <=, >=
-for f in (:+, :-, :*, :<, :>, :<=, :>=)
+import Base: +, -, *, <, >, <=, >=, ==
+for f in (:+, :-, :*, :<, :>, :<=, :>=, :(==))
     @eval $f(a::ChainedVectorIndex, b::Integer) = $f(a.i, b)
     @eval $f(a::Integer, b::ChainedVectorIndex) = $f(a, b.i)
 end

--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -186,19 +186,31 @@ Base.@propagate_inbounds function Base.setindex!(A::ChainedVector, v, i::Integer
 end
 
 # custom index type used in eachindex
-struct ChainedVectorIndex{A}
+struct ChainedVectorIndex{A} <: Integer
     array::A
+    array_i::Int
     i::Int
 end
 
-@inline Base.getindex(x::ChainedVectorIndex) = @inbounds x.array[x.i]
+import Base: +, -, *, <, >, <=, >=
+for f in (:+, :-, :*, :<, :>, :<=, :>=)
+    @eval $f(a::ChainedVectorIndex, b::Integer) = $f(a.i, b)
+    @eval $f(a::Integer, b::ChainedVectorIndex) = $f(a, b.i)
+end
+Base.convert(::Type{T}, x::ChainedVectorIndex) where {T <: Union{Signed, Unsigned}} = x.i
+
+@inline Base.getindex(x::ChainedVectorIndex) = @inbounds x.array[x.array_i]
 
 @inline function Base.getindex(A::ChainedVector, x::ChainedVectorIndex)
-    return @inbounds x.array[x.i]
+    return @inbounds x.array[x.array_i]
+end
+
+function Base.getindex(A::AbstractArray, x::ChainedVectorIndex)
+    return A[x.i]
 end
 
 @inline function Base.setindex!(A::ChainedVector, v, x::ChainedVectorIndex)
-    @inbounds x.array[x.i] = v
+    @inbounds x.array[x.array_i] = v
     return v
 end
 
@@ -229,21 +241,21 @@ end
 @inline function Base.iterate(x::IndexIterator)
     arrays = x.arrays
     length(arrays) == 0 && return nothing
-    chunkidx = 1
+    chunkidx = chunk_i = 1
     @inbounds chunk = arrays[chunkidx]
     # we already ran cleanup! so chunks are guaranteed non-empty
-    return ChainedVectorIndex(chunk, 1), (arrays, chunkidx, chunk, length(chunk), 2)
+    return ChainedVectorIndex(chunk, chunk_i, 1), (arrays, chunkidx, chunk, length(chunk), chunk_i + 1, 2)
 end
 
-@inline function Base.iterate(x::IndexIterator, (arrays, chunkidx, chunk, chunklen, i))
-    if i > chunklen
+@inline function Base.iterate(x::IndexIterator, (arrays, chunkidx, chunk, chunklen, chunk_i, i))
+    if chunk_i > chunklen
         chunkidx += 1
         chunkidx > length(arrays) && return nothing
         @inbounds chunk = arrays[chunkidx]
         chunklen = length(chunk)
-        i = 1
+        chunk_i = 1
     end
-    return ChainedVectorIndex(chunk, i), (arrays, chunkidx, chunk, chunklen, i + 1)
+    return ChainedVectorIndex(chunk, chunk_i, i), (arrays, chunkidx, chunk, chunklen, chunk_i + 1, i + 1)
 end
 
 @inline function Base.iterate(A::ChainedVector)
@@ -591,13 +603,6 @@ function Base.append!(A::ChainedVector{T}, B) where {T}
         push!(A, x)
     end
     return A
-end
-
-function Base.append!(a::Vector, items::ChainedVector)
-    n = length(items)
-    Base._growend!(a, n)
-    copyto!(a, length(a)-n+1, items, 1, n)
-    return a
 end
 
 function Base.prepend!(A::ChainedVector{T, AT}, B::AT) where {T, AT <: AbstractVector{T}}

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -375,8 +375,9 @@
     @test length(x) == 6
     @test x == [1, 2, 3, 1, 2, 3]
 
+    x = ChainedVector([[1,2,3], [4,5,6], [7,8,9,10]])
     for (i, idx) in enumerate(eachindex(x))
-       @test i == idx.i
+       @test i == idx
     end
 
     i1 = first(eachindex(x))

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -374,6 +374,17 @@
     append!(x, ChainedVector([[1, 2, 3]]))
     @test length(x) == 6
     @test x == [1, 2, 3, 1, 2, 3]
+
+    for (i, idx) in enumerate(eachindex(x))
+       @test i == idx.i
+    end
+
+    i1 = first(eachindex(x))
+    @test convert(Int,  i1) isa Int
+    @test convert(Int8,  i1) isa Int8
+    @test i1 == 1
+    @test i1 < 2
+    @test isless(i1, 2)
 end
 
 @testset "iteration protocol on ChainedVector" begin

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -369,6 +369,11 @@
 
     # https://github.com/JuliaData/CSV.jl/issues/842
     @test size(eachindex(ChainedVector([["a"]]))) == (1,)
+
+    x = [1, 2, 3]
+    append!(x, ChainedVector([[1, 2, 3]]))
+    @test length(x) == 6
+    @test x == [1, 2, 3, 1, 2, 3]
 end
 
 @testset "iteration protocol on ChainedVector" begin


### PR DESCRIPTION
Hopefully resolves issues like those raised in #52 (which this fixes
specifically). To make `ChainedVectorIndex` act like a normal array
index, we need to carry around the "total index" value instead of just
the current array + local array index. We also add some simple integer
definitions for `ChainedVectorIndex` so it can act like an Integer. An
alternative strategy would be to just define appropriate promote/convert
definitions and not arithmetic/comparison directly.