### PR TITLE
Define has for ChainedVectorIndex

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -207,6 +207,7 @@ for f in (:+, :-, :*, :<, :>, :<=, :>=, :(==))
     @eval $f(a::Integer, b::ChainedVectorIndex) = $f(a, b.i)
 end
 Base.convert(::Type{T}, x::ChainedVectorIndex) where {T <: Union{Signed, Unsigned}} = convert(T, x.i)
+Base.hash(x::ChainedVectorIndex, h::UInt) = hash(x.i, h)
 
 @inline Base.getindex(x::ChainedVectorIndex) = @inbounds x.array[x.array_i]
 

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -458,6 +458,7 @@ end
     for (aidx, bidx) in zip(eachindex(x), eachindex(y))
         # getindex w/ custom ChainedVectorIndex
         @test x[aidx] == y[bidx]
+        @test hash(aidx) == hash(bidx)
     end
     for (i, idx) in enumerate(eachindex(x))
         # setindex! w/ custom ChainedVectorIndex


### PR DESCRIPTION
Fixes #62. It seems some code path in plotting is storing elements of
`eachindex` in a `Dict`, which is resulting in `hash` being called on
our custom index type `ChainedVectorIndex`. As a reminder, Our
`ChainedVectorIndex` is _basically_ a plain Integer, but we just keep
track of the current array/array index of the individual chunk we're
iterating which makes iteration overall on `ChainedVector`s much more
efficient. So, the fix here is pretty simply in that we just define
`hash` to forward to the underlying index.