### PR TITLE
Avoid ambiguities for basic ChainedVectorIndex operations

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -205,6 +205,7 @@ import Base: +, -, *, <, >, <=, >=, ==
 for f in (:+, :-, :*, :<, :>, :<=, :>=, :(==))
     @eval $f(a::ChainedVectorIndex, b::Integer) = $f(a.i, b)
     @eval $f(a::Integer, b::ChainedVectorIndex) = $f(a, b.i)
+    @eval $f(a::ChainedVectorIndex, b::ChainedVectorIndex) = $f(a.i, b.i)
 end
 Base.convert(::Type{T}, x::ChainedVectorIndex) where {T <: Union{Signed, Unsigned}} = convert(T, x.i)
 Base.hash(x::ChainedVectorIndex, h::UInt) = hash(x.i, h)

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -457,6 +457,7 @@ end
     end
     for (aidx, bidx) in zip(eachindex(x), eachindex(y))
         # getindex w/ custom ChainedVectorIndex
+        @test aidx == bidx
         @test x[aidx] == y[bidx]
         @test hash(aidx) == hash(bidx)
     end


### PR DESCRIPTION
Fixes #65. Because we were defining operations like `==` for a mix of
`ChainedVectorIndex` and `Integer`, we introduced ambiguities when
comparing two `ChainedVectorIndex`. The fix here is as the abiguity
error suggests, defining the missing operation.