### PR TITLE
Define Base.unaliascopy for ChainedVector

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -425,6 +425,11 @@ function Base.copy(A::ChainedVector{T}) where {T}
     return B
 end
 
+function Base.unaliascopy(x::ChainedVector{T, A}) where {T, A}
+    arrays = map(copy, x.arrays)
+    return ChainedVector{T, A}(arrays, copy(x.inds))
+end
+
 function Base.resize!(A::ChainedVector{T, AT}, len) where {T, AT}
     len >= 0 || throw(ArgumentError("`len` must be >= 0 when resizing ChainedVector"))
     len′ = length(A)

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -14,6 +14,8 @@
     empty!(x)
     @test length(x) == 0
     @test copy(x) == x
+    @test typeof(Base.unaliascopy(x)) == typeof(x)
+    @test Base.unaliascopy(x) == x
 
     @test_throws ArgumentError resize!(x, -1)
     resize!(x, 10)


### PR DESCRIPTION
Fixes #67. Because we overload `copy` to return a normal `Vector`
instead of `ChainedVector`, we need to define `Base.unaliascopy` to
return an actual `ChainedVector` copy.