### PR TITLE
Fix issue copying between two ChainedVectors

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -397,11 +397,15 @@ function Base.copyto!(dest::ChainedVector{T}, doffs::Union{Signed, Unsigned},
             didx += 1
             @inbounds dchunk = dest.arrays[didx]
             di = 1
+        else
+            di += chunkn
         end
         if chunkn == slen
             sidx += 1
             @inbounds schunk = src.arrays[sidx]
             si = 1
+        else
+            si += chunkn
         end
     end
     return dest

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -383,6 +383,14 @@
     x2 = map(identity, x)
     copyto!(x2, 2, y, 2)
     @test x2[2:end] == y[2:end]
+    # https://github.com/JuliaData/SentinelArrays.jl/issues/71
+    x = ChainedVector([SentinelArray(["a", "b", "c"]), SentinelArray(["d", "e", "f"])])
+    y = similar(x, 10)
+    copyto!(y, 4, x)
+    @test y[4:9] == x
+    for i in [1, 2, 3, 10]
+        @test !isassigned(y, i)
+    end
 
     # https://github.com/JuliaData/SentinelArrays.jl/issues/45
     a = []


### PR DESCRIPTION
Fixes #71. The core issue here is copyto had bad logic when the
copying straddled two subarrays of different lengths between
the two ChainedVectors being copied.