### PR TITLE
make insert! consistent with Base Julia

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -566,6 +566,7 @@ function Base.popfirst!(A::ChainedVector)
 end
 
 Base.@propagate_inbounds function Base.insert!(A::ChainedVector{T, AT}, i::Integer, item) where {T, AT <: AbstractVector{T}}
+    i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))
     if i == 1 && length(A.arrays) == 0
         push!(A.arrays, similar(AT, 0))
         push!(A.inds, 0)

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -47,6 +47,7 @@
     @test_throws ArgumentError pop!(x)
     @test_throws ArgumentError popfirst!(x)
 
+    @test_throws ArgumentError insert!(x, true, 1)
     @test_throws BoundsError insert!(x, 0, 1)
     @test_throws BoundsError insert!(x, 2, 1)
     insert!(x, 1, 1)


### PR DESCRIPTION
Base Julia does not allow `Bool` index in `insert!`:
```
julia> insert!([1, 2], true, 3)
ERROR: ArgumentError: invalid index: true of type Bool

julia> insert!(ChainedVector([[1, 2]]), true, 3)
3-element ChainedVector{Int64, Vector{Int64}}:
 3
 1
 2
```