### PR TITLE
Define nextind/prevind for ChainedVectorIndex

### DIFF
--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -510,3 +510,19 @@ end
     append!(x, [2])
     @test x[end] == 2
 end
+
+@testset "prevind/nextind ChainedVector" begin
+    x = ChainedVector([collect(1:i) for i = 10:100])
+    ind = first(eachindex(x))
+    for i = 1:length(x)
+        @test x[ind] == x[i]
+        ind = nextind(x, ind)
+    end
+    for i = length(x):-1:1
+        @test x[ind] == x[i]
+        ind = prevind(x, ind)
+    end
+    # https://github.com/JuliaData/SentinelArrays.jl/issues/74
+    x = ChainedVector([[true], [false], [true]])
+    @test BitVector(x) == [true, false, true]
+end

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -194,7 +194,7 @@
     # https://github.com/JuliaData/SentinelArrays.jl/issues/57
     cx1 = ChainedVector([[1, 2], [3]])
     cx2 = ChainedVector([[1.1, 2.2], [3.3]])
-    @test ChainedVector([cx1, cx2]) isa ChainedVector{Float64, <:ChainedVector{Float64}}
+    @test ChainedVector([cx1, cx2]) isa ChainedVector{Float64}
 
     x = ChainedVector([[1], [2], [3]])
     y = map(v -> v == 1 ? missing : v, x)

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -518,10 +518,13 @@ end
         @test x[ind] == x[i]
         ind = nextind(x, ind)
     end
+    @test_throws BoundsError x[ind]
     for i = length(x):-1:1
-        @test x[ind] == x[i]
         ind = prevind(x, ind)
+        @test x[ind] == x[i]
     end
+    ind = prevind(x, ind)
+    @test_throws BoundsError x[ind]
     # https://github.com/JuliaData/SentinelArrays.jl/issues/74
     x = ChainedVector([[true], [false], [true]])
     @test BitVector(x) == [true, false, true]


### PR DESCRIPTION
The `BitVector(::AbstractVector{Bool})` method uses the `Base.nextind` method to increment the inds from `eachindex` that I didn't know existed. I'm not exactly sure why they use that instead of just iterating `eachindex` but it turns out we can define `nextind` to be pretty efficient for `ChainedVectorIndex` since we basically already have that logic in `eachindex(::ChainedVector)`.

Fixes the issue reported in https://github.com/JuliaData/SentinelArrays.jl/issues/74.