### PR TITLE
Use global system RNG

### DIFF
--- a/src/SentinelArrays.jl
+++ b/src/SentinelArrays.jl
@@ -4,16 +4,6 @@ using Dates, Random
 
 export SentinelArray, SentinelMatrix, SentinelVector, SentinelCollisionError, ChainedVector, MissingVector
 
-const RNG = []
-
-function __init__()
-    nthr = Threads.nthreads()
-    resize!(RNG, nthr)
-    for i = 1:nthr
-        RNG[i] = MersenneTwister()
-    end
-end
-
 """
     SentinelArray(A::AbstractArray, sentinel, value)
     SentinelVector{T}(undef, len, sentinel, value)
@@ -75,7 +65,7 @@ const SentinelMatrix{T} = SentinelArray{T, 2}
 
 defaultvalue(T) = missing
 
-newsentinel(T) = !isbitstype(T) ? undef : reinterpret(T, rand(RNG[Threads.threadid()], UInt8, sizeof(T)))[1]
+newsentinel(T) = !isbitstype(T) ? undef : reinterpret(T, rand(UInt8, sizeof(T)))[1]
 defaultsentinel(T) = !isbitstype(T) ? undef : Base.issingletontype(T) ? throw(ArgumentError("singleton type $T not allowed in a SentinelArray")) : reinterpret(T, fill(0xff, sizeof(T)))[1]
 
 # constructors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using SentinelArrays, Test, Random
 # then tried to `setindex!` to the _NEXT_ chosen sentinel value
 # then the element getting set would end up `missing` (because it == the sentinel value)
 # instead of the sentinel value getting cycled to something else
-Random.seed!(SentinelArrays.RNG[1], 0)
+Random.seed!(0)
 x = SentinelVector{Int64}(undef, 1)
 x[1] = 1
 x.sentinel = 1369352191816061504


### PR DESCRIPTION
On my system that gets rid of about 100ms of package load time.

Before:
```
348.6 ms  SentinelArrays 31.04% compilation time
```
After:
```
242.6 ms  SentinelArrays
```

My understanding is that the global RNG is thread-safe (and thread-local) since Julia 1.3, which is the min Julia version for this package, so I don't think there is actually any need for this package specific thread-local RNG creation, right? See https://github.com/JuliaLang/julia/blob/master/HISTORY.md#multi-threading-changes-5.