### PR TITLE
Fix processing of ind in similar

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -327,7 +327,8 @@ end
 Base.similar(x::ChainedVector) = similar(x, length(x))
 Base.similar(x::ChainedVector{T}, len::Base.DimOrInd) where {T} = similar(x, T, len)
 
-function Base.similar(x::ChainedVector{T}, ::Type{S}, len::Base.DimOrInd=length(x)) where {T, S}
+function Base.similar(x::ChainedVector{T}, ::Type{S}, _len::Base.DimOrInd=length(x)) where {T, S}
+    len = _len isa Integer ? _len : length(_len)
     if len == length(x)
         # return same chunks structure as x
         return ChainedVector([similar(A, S, length(A)) for A in x.arrays])

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -417,6 +417,10 @@
     @test i1 == 1
     @test i1 < 2
     @test isless(i1, 2)
+
+    # https://github.com/JuliaData/SentinelArrays.jl/issues/79
+    v = ChainedVector([rand(5), rand(5)])
+    @test (rand(10,10) * v) isa ChainedVector
 end
 
 @testset "iteration protocol on ChainedVector" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaData/SentinelArrays.jl/issues/79. We only treated the `len` argument in our `ChainedVector` `similar` method as an `Integer` and not if it was a `OneTo`.