### PR TITLE
Add an assert in ChainedVectorIndex checkbounds

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -213,7 +213,10 @@ Base.hash(x::ChainedVectorIndex, h::UInt) = hash(x.i, h)
 
 @inline Base.getindex(x::ChainedVectorIndex) = @inbounds x.array[x.array_i]
 
-Base.checkbounds(::Type{Bool}, A::ChainedVector, ind::ChainedVectorIndex) = 1 <= ind.array_i <= length(ind.array)
+function Base.checkbounds(::Type{Bool}, A::ChainedVector, ind::ChainedVectorIndex)
+    @assert ind.array === A.arrays[ind.arrays_i] "indexing ChainedVector with wrong ChainedVectorIndex"
+    return 1 <= ind.array_i <= length(ind.array)
+end
 
 Base.@propagate_inbounds function Base.getindex(A::ChainedVector, x::ChainedVectorIndex)
     @boundscheck checkbounds(A, x)

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -529,6 +529,9 @@ end
     end
     ind = prevind(x, ind)
     @test_throws BoundsError x[ind]
+    # https://github.com/apache/arrow-julia/issues/418
+    y = ChainedVector([collect(1:i) for i = 10:100])
+    @test_throws AssertionError x[first(eachindex(y))]
     # https://github.com/JuliaData/SentinelArrays.jl/issues/74
     x = ChainedVector([[true], [false], [true]])
     @test BitVector(x) == [true, false, true]


### PR DESCRIPTION
Fixes https://github.com/apache/arrow-julia/issues/418. The issue here is that a ChainedVectorIndex is really only valid for the ChainedVector it came from, so assert that in checkbounds, which can be compiled away w/ the checkbounds functionality if an indexing operation is marked `@inbounds`.