### PR TITLE
fix out-of-bounds bug in BufferedVector

### DIFF
--- a/src/BufferedVectors.jl
+++ b/src/BufferedVectors.jl
@@ -55,7 +55,7 @@ function shiftleft!(x::BufferedVector, n)
         empty!(x)
         return nothing
     end
-    unsafe_copyto!(x.elements, 1, x.elements, 1 + n, len - n + 1)
+    unsafe_copyto!(x.elements, 1, x.elements, 1 + n, len - n)
     x.occupied -= n
     return nothing
 end


### PR DESCRIPTION
The OOB read was caught by https://github.com/JuliaLang/julia/pull/51319. Although this code seems like it probably should be deleted, since it appears to be identical in features to Array but with worse heuristics and implementations.