### PR TITLE
Add compat bounds for `Dates` and `Random`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,8 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+Dates = "<0.0.1, 1"
+Random = "<0.0.1, 1"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Following this guide https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958#update-november-2nd-2023-how-do-i-determine-what-the-compat-entry-should-be-for-a-stdlib-1, since we are supporting Julia 1.3, we use the `"<0.0.1, 1"` compat bounds.