### PR TITLE
Improve getindex performance on ChainedVector with UnitRanges

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -187,10 +187,11 @@ end
 Base.@propagate_inbounds function Base.getindex(x::ChainedVector{T, A}, inds::UnitRange{Int}) where {T, A}
     isempty(inds) && return similar(x, 0)
     len = length(inds)
-    res = similar(x.arrays[1], len)
-    chunk = j = ind = 1
-    chunklen = length(x.arrays[1])
     arrays = x.arrays
+    res = similar(arrays[1], len)
+    chunk = j = ind = 1
+    chunklen = length(arrays[1])
+
     # linearindex first item
     chunk, chunklen, j = linearindex(x, chunk, chunklen, j, ind, inds[1])
     @inbounds arraychunk = arrays[chunk]

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -734,3 +734,14 @@ end
         @test deleteat!(v2, m2) == deleteat!(s2, m2)
     end
 end
+
+@testset "getindex with UnitRange" begin
+    x = ChainedVector([collect(1:i) for i = 10:100])
+    @test isempty(x[1:0])
+    @test x[1:1] == [1]
+    @test x[1:end] == x
+    y = collect(x)
+    for i = 1:length(x), j = 1:length(x)
+        @test x[i:j] == y[i:j]
+    end
+end


### PR DESCRIPTION
Before:
```julia
julia> using SentinelArrays, Chairmarks

julia> function f(inputs, range)
           ChainedVector(inputs)[range]
       end
f (generic function with 1 method)

julia> function g(inputs, range)
           reduce(vcat, inputs)[range]
       end
g (generic function with 1 method)

julia> vinputs = [rand(Float32, rand(1024:2048)) for _ = 1:90];

julia> @b f(vinputs, 1:95000)
64.666 μs (9 allocs: 372.125 KiB)
```

After:
```julia
julia> @b f(vinputs, 1:95000)
13.875 μs (9 allocs: 372.125 KiB)
```