### PR TITLE
Fix `getindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SentinelArrays"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.4.6"
+version = "1.4.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -677,6 +677,8 @@ end
     @test length(x) == 0
     @test_throws BoundsError x[1]
     @test_throws BoundsError x[end]
+    @test isempty(@inferred(x[Int[]]))
+    @test isempty(@inferred(x[2:1]))
 
     push!(x, 1)
     @test x[end] == 1
@@ -743,5 +745,20 @@ end
     y = collect(x)
     for i = 1:length(x), j = 1:length(x)
         @test x[i:j] == y[i:j]
+    end
+
+    # #107
+    for f in (identity, collect)
+        x = ChainedVector([f(1:2), f(3:4)])
+        @test @inferred(x[2:3]) == 2:3
+        @test @inferred(x[3:2]) == Int[]
+    end
+end
+
+@testset "getindex type-inference" begin
+    for f in (identity, collect)
+        x = ChainedVector([f(1:2), f(3:4)])
+        @test @inferred(x[[2,3]]) == 2:3
+        @test @inferred(x[Int[]]) == Int[]
     end
 end


### PR DESCRIPTION
Fixes #107 and fixes #109 by using `copyto!` instead of `unsafe_copyto!`.

Additionally, I fixed type stability of `getindex` and support for empty `ChainedVector`s.

Currently on the main branch:

```julia
julia> x = ChainedVector([[1, 2], [3, 4]]);

julia> x[Int[]]
0-element ChainedVector{Int64, Vector{Int64}}

julia> x[2:1]
0-element ChainedVector{Int64, Vector{Int64}}

julia> x[[2,3]]
2-element Vector{Int64}:
 2
 3

julia> x[2:3]
2-element Vector{Int64}:
 2
 3

julia> x = ChainedVector([[]]);

julia> x[Int[]]
0-element ChainedVector{Any, Vector{Any}}

julia> x[2:1]
0-element ChainedVector{Any, Vector{Any}}
```

With this PR:

```julia
julia> x = ChainedVector([[1, 2], [3, 4]]);

julia> x[Int[]]
Int64[]

julia> x[2:1]
Int64[]

julia> x[[2,3]]
2-element Vector{Int64}:
 2
 3

julia> x[2:3]
2-element Vector{Int64}:
 2
 3

julia> x = ChainedVector([[]]);

julia> x[Int[]]
Any[]

julia> x[2:1]
Any[]
```

I don't see any performance regression with this PR in the benchmark in #105, on the contrary probably due to the type inference fixes the PR reduces the number of allocations:

Currently on the main branch:

```julia
julia> @b f($vinputs, $(1:95000))
10.083 μs (9 allocs: 372.125 KiB)

julia> @b g($vinputs, $(1:95000))
18.750 μs (8 allocs: 904.703 KiB)
```

With this PR:

```julia
julia> @b f($vinputs, $(1:95000))
8.875 μs (5 allocs: 372.016 KiB)

julia> @b g($vinputs, $(1:95000))
19.042 μs (8 allocs: 897.328 KiB)
```