### PR TITLE
Fix resize! on ChainedVector

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -546,8 +546,8 @@ function Base.resize!(A::ChainedVector{T, AT}, len) where {T, AT}
         resize!(A.arrays, chunk)
         resize!(A.inds, chunk)
         # resize individual chunk
-        resize!(A.arrays[chunk], A.inds[chunk] - len)
-        A.inds[chunk] -= A.inds[chunk] - len
+        resize!(A.arrays[chunk], length(A.arrays[chunk]) - (A.inds[chunk] - len))
+        A.inds[chunk] = len
     end
     return A
 end

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -710,6 +710,20 @@ end
     @test BitVector(x) == [true, false, true]
 end
 
+# https://github.com/JuliaData/SentinelArrays.jl/issues/110
+@testset "Resizing ChainedVector" begin
+    c = ChainedVector([[:a],[:b1,:b2,:b3],[:c]])
+    @test length(resize!(c,6)) == 6
+    @test resize!(c,5) == [:a,:b1,:b2,:b3,:c]
+    @test resize!(c,4) == [:a,:b1,:b2,:b3]
+    @test resize!(c,3) == [:a,:b1,:b2]
+    @test resize!(c,2) == [:a,:b1]
+    @test resize!(c,1) == [:a]
+    @test resize!(c,0) == []
+
+    @test sum(unique!(ChainedVector([[1],[2],[3]]))) == 6
+end
+
 @testset "MissingVector resizing" begin
     v = MissingVector(1)
     @test isequal(push!(v, missing), [missing, missing])


### PR DESCRIPTION
Fix https://github.com/JuliaData/SentinelArrays.jl/issues/110

The last chunk wasn't handled properly when resizing, leading to errors downstream in sort, unique! and so on.