### PR TITLE
remove unused function `over()`

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -147,11 +147,6 @@ end
     return chunk, chunklen, chunklen - (ind - i2)
 end
 
-function over(len, N=Threads.nthreads())
-    nlen, r = divrem(len, N)
-    return (((i - 1) * nlen + 1, i * nlen + ifelse(i == N, r, 0)) for i = 1:N)
-end
-
 Base.@propagate_inbounds function Base.getindex(x::ChainedVector{T, A}, inds::AbstractVector{Int}) where {T, A}
     len = length(inds)
     arrays = x.arrays


### PR DESCRIPTION
I've no idea why this function is defined, its not used anyhwere, so we might be able to remove it all together.