### PR TITLE
fix map!(f,dest::ChainedVector,src::AbstractVector)

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -761,26 +761,16 @@ Base.map(f::F, x::ChainedVector) where {F} = ChainedVector([map(f, y) for y in x
 
 function Base.map!(f::F, A::AbstractVector, x::ChainedVector) where {F}
     length(A) >= length(x) || throw(ArgumentError("destination must be at least as long as map! source"))
-    idx = eachindex(A)
-    st = iterate(idx)
-    for array in x.arrays
-        for y in array
-            @inbounds A[st[1]] = f(y)
-            st = iterate(idx, st[2])
-        end
+    for (i, j) in zip(eachindex(A), eachindex(x))
+        @inbounds A[i] = f(x[j])
     end
     return A
 end
 
 function Base.map!(f::F, x::ChainedVector, A::AbstractVector) where {F}
     length(x) >= length(A) || throw(ArgumentError("destination must be at least as long as map! source"))
-    idx = eachindex(A)
-    st = iterate(idx)
-    for array in x.arrays
-        for j in eachindex(array)
-            @inbounds array[j] = f(A[st[1]])
-            st = iterate(idx, st[2])
-        end
+    for (i, j) in zip(eachindex(x), eachindex(A))
+        @inbounds x[i] = f(A[j])
     end
     return x
 end

--- a/test/chainedvector.jl
+++ b/test/chainedvector.jl
@@ -225,6 +225,9 @@
     y = ChainedVector([[1,2,3], [4,5,6,7], [8,9,10]])
     map!(x -> x + 1, x, y)
     @test all(x -> x[1] + 1 == x[2], zip(y, x))
+    x = ChainedVector([[1,2,3], [4,5,6]])
+    y = [1,2]
+    @test map!(x -> x + 10, x, y)== [11,12,3,4,5,6]
 
     # reductions
     x = ChainedVector([[1,2,3], [4,5,6], [7,8,9,10]])


### PR DESCRIPTION
Fixes https://github.com/JuliaData/SentinelArrays.jl/issues/115

With this PR the src is iterated instead of the probably longer destination.

Performance is better on this PR:
```
a,b=ChainedVector([rand(Int,5) for _ in 1:20000]),[1:100000...] # many chunks
@btime map!(i->-i,a,b)
# main: 188us
# pr: 153us

a,b=ChainedVector([[1:100000...]]),[1:100000...] # one chunk
@btime map!(i->-i,a,b)
# main: 171us
# pr: 73.8us
