### PR TITLE
Improve deleteat!(x,::Integer)

### DIFF
--- a/src/chainedvector.jl
+++ b/src/chainedvector.jl
@@ -577,12 +577,19 @@ end
 Base.@propagate_inbounds function Base.deleteat!(A::ChainedVector, i::Integer)
     @boundscheck checkbounds(A, i)
     chunk, ix = index(A, i)
-    deleteat!(A.arrays[chunk], ix)
-    for j = chunk:length(A.inds)
+    lastchunk = length(A.inds)
+    if length(A.arrays[chunk]) == 1
+        deleteat!(A.arrays, chunk)
+        deleteat!(A.inds, chunk)
+        lastchunk -= 1
+        resize!(A.arrays, lastchunk)
+        resize!(A.inds, lastchunk)
+    else
+        deleteat!(A.arrays[chunk], ix)
+    end
+    for j = chunk:lastchunk
         @inbounds A.inds[j] -= 1
     end
-    # check if we should remove an empty chunk
-    cleanup!(A)
     return A
 end
 


### PR DESCRIPTION
We only need to remove one element from a ChainedVector and can therefore special case the fact that if this element is a single entry in a chunk the chunk can be removed completely. This reliefs us from the slow `cleanup!()` call.
As a result dependent functions performance improve: 

### `pop!()` with many chunks
```
julia> function popall(x)
           while length(x) >0
               pop!(x)
           end
       end
popall (generic function with 1 method)

julia> popall(ChainedVector([[1]])); # compilation

julia> cv = ChainedVector([rand(Int,5) for _ in 1:20000]);

julia> @time popall(cv) # main
  1.043174 seconds

julia> @time popall(cv) # pr
  0.003701 seconds

```


### `popfirst!()` with many chunks

```
julia> function popall(x)
           while length(x) >0
               popfirst!(x)
           end
       end
popall (generic function with 1 method)

julia> popall(ChainedVector([[1]])); # compilation

julia> cv = ChainedVector([rand(Int,5) for _ in 1:20000]);

julia> @time popall(cv) # main
  1.423213 seconds

julia> @time popall(cv) # pr
  0.128358 seconds 
```

### `popfirst!()` with single chunk
```
julia> function popall(x)
           while length(x) >0
               popfirst!(x)
           end
       end
popall (generic function with 1 method)

julia> popall(ChainedVector([[1]])); # compilation

julia> cv = ChainedVector([rand(Int,100000)]);

julia> @time popall(cv)
  0.002024 seconds # main

julia> @time popall(cv)
  0.001135 seconds # pr

```